### PR TITLE
add group metadata endpoint

### DIFF
--- a/controllers/groupsController.js
+++ b/controllers/groupsController.js
@@ -1,8 +1,19 @@
-import { getSession, getChatList, isExists, sendMessage, formatGroup } from './../whatsapp.js'
+import { getSession, getChatList, isExists, sendMessage, formatGroup, getGroupMeta } from './../whatsapp.js'
 import response from './../response.js'
 
 const getList = (req, res) => {
     return response(res, 200, true, '', getChatList(res.locals.sessionId, true))
+}
+
+const getGroupMetaData = async (req, res) => {
+    const session = getSession(res.locals.sessionId)
+    const jid = req.params.jid
+    let data
+
+
+    data = await getGroupMeta(session, jid)
+
+    response(res, 200, true, '', data)
 }
 
 const send = async (req, res) => {
@@ -25,4 +36,4 @@ const send = async (req, res) => {
     }
 }
 
-export { getList, send }
+export { getList, send, getGroupMetaData }

--- a/routes/groupsRoute.js
+++ b/routes/groupsRoute.js
@@ -9,7 +9,10 @@ const router = Router()
 
 router.get('/', query('id').notEmpty(), requestValidator, sessionValidator, controller.getList)
 
+router.get('/meta/:jid', query('id').notEmpty(), requestValidator, sessionValidator, controller.getGroupMetaData)
+
 router.get('/:jid', query('id').notEmpty(), requestValidator, sessionValidator, getMessages)
+
 
 router.post(
     '/send',

--- a/whatsapp.js
+++ b/whatsapp.js
@@ -183,6 +183,13 @@ const getChatList = (sessionId, isGroup = false) => {
     })
 }
 
+const getGroupMeta = async (session, jid) => {
+    let data
+    data = await session.groupMetadata(jid)
+    
+    return data
+}
+
 /**
  * @param {import('@adiwajshing/baileys').AnyWASocket} session
  */
@@ -287,4 +294,5 @@ export {
     formatGroup,
     cleanup,
     init,
+    getGroupMeta,
 }


### PR DESCRIPTION
## Rationale
Although there is a function in Baileys to retrieve metadata (owner, participants, etc.) of any group, there is no endpoint in the API to meet this function. Since I need the metadata of some groups, I added this endpoint and made it available to you. I hope it works!

Detail: Issuse: #39 Get Group Members

## POC for Meta Endpoint
Look the changes please.

## Changes:
controllers/groupsController.js -> Add new function for view group meta data.
routes/groupsRoute.js -> Add new GET method for view group meta data.
whatsapp.js -> I have no idea, I tried to code according to the general structure.

## Notes
I've never used Node JS or similar technology before, unfortunately it's an area I'm pretty far from. I had a very difficult time correcting the defect. Please help me improve this PR.