### PR TITLE
fix: correct typo 'occured' -> 'occurred' in error messages

### DIFF
--- a/src/wa.ts
+++ b/src/wa.ts
@@ -77,7 +77,7 @@ export async function createSession(options: createSessionOptions) {
         prisma.session.deleteMany({ where: { sessionId } }),
       ]);
     } catch (e) {
-      logger.error(e, 'An error occured during session destroy');
+      logger.error(e, 'An error occurred during session destroy');
     } finally {
       sessions.delete(sessionId);
     }
@@ -111,7 +111,7 @@ export async function createSession(options: createSessionOptions) {
           res.status(200).json({ qr });
           return;
         } catch (e) {
-          logger.error(e, 'An error occured during QR generation');
+          logger.error(e, 'An error occurred during QR generation');
           res.status(500).json({ error: 'Unable to generate QR' });
         }
       }
@@ -125,7 +125,7 @@ export async function createSession(options: createSessionOptions) {
       try {
         qr = await toDataURL(connectionState.qr);
       } catch (e) {
-        logger.error(e, 'An error occured during QR generation');
+        logger.error(e, 'An error occurred during QR generation');
       }
     }
 


### PR DESCRIPTION
## Summary
Fix typo `occured` → `occurred` in user-facing error messages in `src/wa.ts`:

- Line 80: `'An error occured during session destroy'` 
- Line 114: `'An error occured during QR generation'`
- Line 128: `'An error occured during QR generation'`

Minimal fix: 1 file, 3 line changes (all identical typo corrections)