### PR TITLE
fix: correct 'occured' to 'occurred' typo in error messages

### DIFF
--- a/src/controllers/chat.ts
+++ b/src/controllers/chat.ts
@@ -21,7 +21,7 @@ export const list: RequestHandler = async (req, res) => {
         chats.length !== 0 && chats.length === Number(limit) ? chats[chats.length - 1].pkId : null,
     });
   } catch (e) {
-    const message = 'An error occured during chat list';
+    const message = 'An error occurred during chat list';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -49,7 +49,7 @@ export const find: RequestHandler = async (req, res) => {
           : null,
     });
   } catch (e) {
-    const message = 'An error occured during chat find';
+    const message = 'An error occurred during chat find';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }

--- a/src/controllers/contact.ts
+++ b/src/controllers/contact.ts
@@ -22,7 +22,7 @@ export const list: RequestHandler = async (req, res) => {
           : null,
     });
   } catch (e) {
-    const message = 'An error occured during contact list';
+    const message = 'An error occurred during contact list';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -34,7 +34,7 @@ export const listBlocked: RequestHandler = async (req, res) => {
     const data = await session.fetchBlocklist();
     res.status(200).json(data);
   } catch (e) {
-    const message = 'An error occured during blocklist fetch';
+    const message = 'An error occurred during blocklist fetch';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -51,7 +51,7 @@ export const updateBlock: RequestHandler = async (req, res) => {
     await session.updateBlockStatus(jid, action);
     res.status(200).json({ message: `Contact ${action}ed` });
   } catch (e) {
-    const message = 'An error occured during blocklist update';
+    const message = 'An error occurred during blocklist update';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -65,7 +65,7 @@ export const check: RequestHandler = async (req, res) => {
     const exists = await jidExists(session, jid);
     res.status(200).json({ exists });
   } catch (e) {
-    const message = 'An error occured during jid check';
+    const message = 'An error occurred during jid check';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }

--- a/src/controllers/group.ts
+++ b/src/controllers/group.ts
@@ -22,7 +22,7 @@ export const list: RequestHandler = async (req, res) => {
           : null,
     });
   } catch (e) {
-    const message = 'An error occured during group list';
+    const message = 'An error occurred during group list';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -35,7 +35,7 @@ export const find: RequestHandler = async (req, res) => {
     const data = await session.groupMetadata(jid);
     res.status(200).json(data);
   } catch (e) {
-    const message = 'An error occured during group metadata fetch';
+    const message = 'An error occurred during group metadata fetch';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }

--- a/src/controllers/message.ts
+++ b/src/controllers/message.ts
@@ -27,7 +27,7 @@ export const list: RequestHandler = async (req, res) => {
           : null,
     });
   } catch (e) {
-    const message = 'An error occured during message list';
+    const message = 'An error occurred during message list';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -44,7 +44,7 @@ export const send: RequestHandler = async (req, res) => {
     const result = await session.sendMessage(jid, message, options);
     res.status(200).json(result);
   } catch (e) {
-    const message = 'An error occured during message send';
+    const message = 'An error occurred during message send';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }
@@ -70,7 +70,7 @@ export const sendBulk: RequestHandler = async (req, res) => {
       const result = await session.sendMessage(jid, message, options);
       results.push({ index, result });
     } catch (e) {
-      const message = 'An error occured during message send';
+      const message = 'An error occurred during message send';
       logger.error(e, message);
       errors.push({ index, error: message });
     }
@@ -98,7 +98,7 @@ export const download: RequestHandler = async (req, res) => {
     res.write(buffer);
     res.end();
   } catch (e) {
-    const message = 'An error occured during message media download';
+    const message = 'An error occurred during message media download';
     logger.error(e, message);
     res.status(500).json({ error: message });
   }

--- a/src/controllers/misc.ts
+++ b/src/controllers/misc.ts
@@ -15,7 +15,7 @@ export const makePhotoURLHandler =
       const url = await session.profilePictureUrl(jid, 'image');
       res.status(200).json({ url });
     } catch (e) {
-      const message = 'An error occured during photo fetch';
+      const message = 'An error occurred during photo fetch';
       logger.error(e, message);
       res.status(500).json({ error: message });
     }

--- a/src/wa.ts
+++ b/src/wa.ts
@@ -77,7 +77,7 @@ export async function createSession(options: createSessionOptions) {
         prisma.session.deleteMany({ where: { sessionId } }),
       ]);
     } catch (e) {
-      logger.error(e, 'An error occured during session destroy');
+      logger.error(e, 'An error occurred during session destroy');
     } finally {
       sessions.delete(sessionId);
     }
@@ -111,7 +111,7 @@ export async function createSession(options: createSessionOptions) {
           res.status(200).json({ qr });
           return;
         } catch (e) {
-          logger.error(e, 'An error occured during QR generation');
+          logger.error(e, 'An error occurred during QR generation');
           res.status(500).json({ error: 'Unable to generate QR' });
         }
       }
@@ -125,7 +125,7 @@ export async function createSession(options: createSessionOptions) {
       try {
         qr = await toDataURL(connectionState.qr);
       } catch (e) {
-        logger.error(e, 'An error occured during QR generation');
+        logger.error(e, 'An error occurred during QR generation');
       }
     }
 


### PR DESCRIPTION
Fix 15 instances of 'occured' → 'occurred' typo across 6 files:

- src/wa.ts: 3 instances (session destroy, QR generation)
- src/controllers/chat.ts: 3 instances
- src/controllers/contact.ts: 4 instances  
- src/controllers/group.ts: 2 instances
- src/controllers/message.ts: 4 instances
- src/controllers/misc.ts: 1 instance

These are error messages returned in API responses to client applications.